### PR TITLE
Update handling of changed files list

### DIFF
--- a/actions/determine-minimal-project-list/determine_changed_files.sh
+++ b/actions/determine-minimal-project-list/determine_changed_files.sh
@@ -5,10 +5,10 @@ determine_changed_files() {
   IFS=$'\n'
   module_paths=($(find . -name "pom.xml" | sed 's|/[^/]*$||' | sed 's| $||' | awk '{ printf "%d %s/\n", length, $0 }' | sort -nr | cut -d" " -f2-))
 
-  changed_files=$1
-
   IFS=' '
-  for file in $changed_files; do
+  changed_files=("$@")
+
+  for file in "${changed_files[@]}"; do
       prefixed_file=./$file
       for module_path in "${module_paths[@]}"; do
           # Check if the file path starts with the module path

--- a/actions/determine-minimal-project-list/tests/test_script.bats
+++ b/actions/determine-minimal-project-list/tests/test_script.bats
@@ -21,10 +21,11 @@ setup() {
 
 @test "affected_modules will include entries for all pom.xml files" {
   source "$BATS_TEST_DIRNAME/../determine_changed_files.sh"
-  run determine_changed_files shared/shared-a/dummy.java
+  run determine_changed_files shared/shared-a/dummy.java shared/shared-c/dummy.java
   [ "$status" -eq 0 ]
   expected=$(cat << EOF
 ./shared/shared-a/
+./shared/shared-c/
 EOF
 )
   [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"
@@ -71,6 +72,17 @@ EOF
 @test "create_project_list will return maven project-list to build all modules affected by changed files in shared-c" {
   source "$BATS_TEST_DIRNAME/../create_project_list.sh"
   run create_project_list shared/shared-c/dummy.java
+  [ "$status" -eq 0 ]
+  expected=$(cat << EOF
+project_list=./services/service-b/,./services/service-a/
+EOF
+)
+  [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"
+}
+
+@test "create_project_list will return maven project-list to build all modules affected by changed files in shared-a and shared-c" {
+  source "$BATS_TEST_DIRNAME/../create_project_list.sh"
+  run create_project_list shared/shared-a/dummy.java shared/shared-c/dummy.java
   [ "$status" -eq 0 ]
   expected=$(cat << EOF
 project_list=./services/service-b/,./services/service-a/


### PR DESCRIPTION
Refactored the script to handle the list of changed files as an array instead of a simple string. This allows considering multiple file changes at once and improves the script's capability to determine affected modules correctly. The corresponding unit tests have been updated to verify this change.