### PR TITLE
Add strip_relative_path function and update project list logic

### DIFF
--- a/actions/determine-minimal-project-list/create_project_list.sh
+++ b/actions/determine-minimal-project-list/create_project_list.sh
@@ -77,11 +77,12 @@ determine_and_handle_changed_files() {
 list_affected_projects() {
     for affected_module in "${AFFECTED_MODULES_MAP[@]}"; do
         local affected_folder=${MAVEN_TO_FOLDER_MAP[$affected_module]}
-        local affected_folder_trimmed=$(trim "$affected_folder")
+        local affected_folder_trimmed
+        affected_folder_trimmed=$(strip_relative_path "$(trim "$affected_folder")")
         PROJECT_LIST["$affected_folder_trimmed"]=$affected_folder_trimmed
     done
     local project_list
-    project_list=$(echo "${PROJECT_LIST[@]}" | sed 's|/./||g' | tr ' ' '\n' | sort -r | tr '\n' ',' )
+    project_list=$(echo "${PROJECT_LIST[@]}" | sed 's|/\./||g' | tr ' ' '\n' | sort -r | tr '\n' ',' )
     # Output the affected projects list
     echo "project_list=${project_list%,}" | tee -a $GITHUB_OUTPUT
 }

--- a/actions/determine-minimal-project-list/tests/test_script.bats
+++ b/actions/determine-minimal-project-list/tests/test_script.bats
@@ -19,6 +19,17 @@ setup() {
   cd $BATS_TEST_DIRNAME/example_monorepo || return
 }
 
+@test "create_project_list will return an empty maven project-list to build all services if no changed files" {
+  source "$BATS_TEST_DIRNAME/../create_project_list.sh"
+  run create_project_list
+  [ "$status" -eq 0 ]
+  expected=$(cat << EOF
+project_list=
+EOF
+)
+  [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"
+}
+
 @test "affected_modules will include entries for all pom.xml files" {
   source "$BATS_TEST_DIRNAME/../determine_changed_files.sh"
   run determine_changed_files shared/shared-a/dummy.java shared/shared-c/dummy.java
@@ -64,7 +75,7 @@ EOF
   run create_project_list shared/shared-a/dummy.java
   [ "$status" -eq 0 ]
   expected=$(cat << EOF
-project_list=./shared/shared-a,./services/service-a
+project_list=shared/shared-a,services/service-a
 EOF
 )
   [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"
@@ -75,7 +86,7 @@ EOF
   run create_project_list shared/shared-c/dummy.java
   [ "$status" -eq 0 ]
   expected=$(cat << EOF
-project_list=./shared/shared-c,./services/service-b,./services/service-a
+project_list=shared/shared-c,services/service-b,services/service-a
 EOF
 )
   [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"
@@ -86,7 +97,7 @@ EOF
   run create_project_list shared/shared-a/dummy.java shared/shared-c/dummy.java
   [ "$status" -eq 0 ]
   expected=$(cat << EOF
-project_list=./shared/shared-c,./shared/shared-a,./services/service-b,./services/service-a
+project_list=shared/shared-c,shared/shared-a,services/service-b,services/service-a
 EOF
 )
   [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"
@@ -97,7 +108,7 @@ EOF
   run create_project_list shared/shared-d/dummy.java
   [ "$status" -eq 0 ]
   expected=$(cat << EOF
-project_list=./shared/shared-d,./shared/shared-c,./services/service-b,./services/service-a
+project_list=shared/shared-d,shared/shared-c,services/service-b,services/service-a
 EOF
 )
   [[ "$output" = "$expected" ]] || fail "$(printf "The output doesn't match the expected value\noutput:\n%s\nexpect:\n%s\n" "$output" "$expected")"

--- a/actions/determine-minimal-project-list/utility.sh
+++ b/actions/determine-minimal-project-list/utility.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+strip_relative_path() {
+  # This will strip any relative path from the given string
+  absolute=$(echo -e "$1" | sed -e 's/^\.\///')
+  echo "$absolute"
+}
+
 trim() {
     # This will remove leading and trailing spaces
     trimmed=$(echo -e "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')


### PR DESCRIPTION
Introduced strip_relative_path to remove relative paths from strings. Updated create_project_list to use this function to clean project paths. Enhanced test coverage to ensure correct handling of relative paths.